### PR TITLE
Fix incorrect behaviour of ezWS2812 brightness

### DIFF
--- a/libraries/ezWS2812/src/ezWS2812.h
+++ b/libraries/ezWS2812/src/ezWS2812.h
@@ -63,9 +63,9 @@ public:
         colors[c] = (uint8_t)color_adj;
       }
     } else if (brightness == 0) {
-      red = 0;
-      green = 0;
-      blue = 0;
+      colors[0] = 0;
+      colors[1] = 0;
+      colors[2] = 0;
     }
 
     // Go through the output array


### PR DESCRIPTION
There is a bug in the current version of the WS2812 driver that would cause an incorrect color value when the brightness is set to 0. The edge case of brightness == 0 was handled, but the values were not assigned to the array correctly.