### PR TITLE
Update Matter Fan Control Cluster to add 'SpeedMax' attribute.

### DIFF
--- a/libraries/Matter/src/MatterFan.cpp
+++ b/libraries/Matter/src/MatterFan.cpp
@@ -39,6 +39,7 @@ DECLARE_DYNAMIC_ATTRIBUTE(FanControl::Attributes::FanMode::Id, INT8U, 1, ATTRIBU
 DECLARE_DYNAMIC_ATTRIBUTE(FanControl::Attributes::FanModeSequence::Id, INT8U, 1, 0),                          /* FanModeSequence */
 DECLARE_DYNAMIC_ATTRIBUTE(FanControl::Attributes::PercentSetting::Id, INT8U, 1, ATTRIBUTE_MASK_WRITABLE),     /* PercentSetting */
 DECLARE_DYNAMIC_ATTRIBUTE(FanControl::Attributes::PercentCurrent::Id, INT8U, 1, 0),                           /* PercentCurrent */
+DECLARE_DYNAMIC_ATTRIBUTE(FanControl::Attributes::SpeedMax::Id, INT8U, 1, 0),                                 /* SpeedMax */
 DECLARE_DYNAMIC_ATTRIBUTE(FanControl::Attributes::FeatureMap::Id, BITMAP32, 4, 0),                            /* FeatureMap */
 DECLARE_DYNAMIC_ATTRIBUTE(FanControl::Attributes::ClusterRevision::Id, INT16U, 2, 0),                         /* ClusterRevision */
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();

--- a/libraries/Matter/src/devices/DeviceFan.cpp
+++ b/libraries/Matter/src/devices/DeviceFan.cpp
@@ -29,7 +29,8 @@
 DeviceFan::DeviceFan(const char* device_name) :
   Device(device_name),
   current_percent(0),
-  current_fan_mode(fan_mode_t::Off)
+  current_fan_mode(fan_mode_t::Off),
+  speedmax(100)
 {
   ;
 }
@@ -63,6 +64,11 @@ uint8_t DeviceFan::GetPercentCurrent()
 void DeviceFan::SetPercentCurrent(uint8_t percent)
 {
   (void)percent;
+}
+
+uint8_t DeviceFan::GetSpeedMax()
+{
+  return this->speedmax;
 }
 
 void DeviceFan::SetFanMode(uint8_t fan_mode)
@@ -150,6 +156,8 @@ EmberAfStatus DeviceFan::HandleReadEmberAfAttribute(ClusterId clusterId,
   } else if ((attributeId == PercentCurrent::Id) && (maxReadLength == 1)) {
     uint8_t percent_current = this->GetPercentCurrent();
     memcpy(buffer, &percent_current, sizeof(percent_current));
+    uint8_t speedmax = this->GetSpeedMax();
+    memcpy(buffer, &speedmax, sizeof(speedmax));
   } else if ((attributeId == FeatureMap::Id) && (maxReadLength == 4)) {
     uint32_t featureMap = this->GetFanClusterFeatureMap();
     memcpy(buffer, &featureMap, sizeof(featureMap));

--- a/libraries/Matter/src/devices/DeviceFan.cpp
+++ b/libraries/Matter/src/devices/DeviceFan.cpp
@@ -156,6 +156,7 @@ EmberAfStatus DeviceFan::HandleReadEmberAfAttribute(ClusterId clusterId,
   } else if ((attributeId == PercentCurrent::Id) && (maxReadLength == 1)) {
     uint8_t percent_current = this->GetPercentCurrent();
     memcpy(buffer, &percent_current, sizeof(percent_current));
+  } else if ((attributeId == SpeedMax::Id) && (maxReadLength == 1)) {    
     uint8_t speedmax = this->GetSpeedMax();
     memcpy(buffer, &speedmax, sizeof(speedmax));
   } else if ((attributeId == FeatureMap::Id) && (maxReadLength == 4)) {

--- a/libraries/Matter/src/devices/DeviceFan.h
+++ b/libraries/Matter/src/devices/DeviceFan.h
@@ -75,6 +75,7 @@ private:
 
   uint8_t current_percent;
   fan_mode_t current_fan_mode;
+  uint8_t speedmax;
 
   static const uint8_t fan_mode_sequence        = 2u;   // Off/Low/Med/High/Auto
   static const uint32_t fan_cluster_feature_map = 1u;   // 1-100 speeds supported

--- a/libraries/Matter/src/devices/DeviceFan.h
+++ b/libraries/Matter/src/devices/DeviceFan.h
@@ -43,6 +43,7 @@ public:
   void SetPercentSetting(uint8_t percent);
   uint8_t GetPercentCurrent();
   void SetPercentCurrent(uint8_t percent);
+  uint8_t GetSpeedMax();
 
   void SetFanMode(uint8_t fan_mode);
   uint8_t GetFanMode();


### PR DESCRIPTION
## Matter Fan Control Cluster

The Matter specifications indicate that this attribute is mandatory but `SpeedMax` attribute is missing for Fan device type.
This poses a problem for integrating this device into Home Assistant and running tests.

### Matter Specification
**Matter-1.3-Application-Cluster-Specification.pdf page 306**

> 4.4.6.5. SpeedMax Attribute
>  This attribute SHALL indicate that the fan has one speed (value of 1) or the maximum speed, if the fan is capable of multiple speeds.

### Testing with Home Assistant
With this fix, the fan is now correctly recognized by [Home Assistant.](https://www.home-assistant.io/)

![image](https://github.com/SiliconLabs/arduino/assets/938089/1543ebdc-ece3-4139-a078-105595c9bedd)
