### PR TITLE
Update matter_decommission.ino

### DIFF
--- a/libraries/Matter/examples/matter_decommission/matter_decommission.ino
+++ b/libraries/Matter/examples/matter_decommission/matter_decommission.ino
@@ -46,17 +46,20 @@ void setup()
   }
   while (!Matter.isDeviceCommissioned()) {
     delay(200);
+    decommission_handler();
   }
 
   Serial.println("Waiting for Thread network...");
   while (!Matter.isDeviceThreadConnected()) {
     delay(200);
+    decommission_handler();
   }
   Serial.println("Connected to Thread network");
 
   Serial.println("Waiting for Matter device discovery...");
   while (!matter_bulb.is_online()) {
     delay(200);
+    decommission_handler();
   }
   Serial.println("Matter device is now online");
 }


### PR DESCRIPTION
I proposed this change because if my board is commissioned and I am far away from any Thread network, I won't be able to decommission it because it will get stuck on the many "while" statements inside the `setup()` function.