### PR TITLE
Incorrect data type INT8U for BOOLEAN flags

### DIFF
--- a/libraries/Matter/src/MatterContact.cpp
+++ b/libraries/Matter/src/MatterContact.cpp
@@ -35,7 +35,7 @@ const EmberAfDeviceType gContactSensorDeviceTypes[] = { { DEVICE_TYPE_CONTACT_SE
 
 // Boolean state cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(booleanStateAttrs)
-DECLARE_DYNAMIC_ATTRIBUTE(BooleanState::Attributes::StateValue::Id, INT8U, 1, 0),               /* StateValue */
+DECLARE_DYNAMIC_ATTRIBUTE(BooleanState::Attributes::StateValue::Id, BOOLEAN, 1, 0),             /* StateValue */
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();                                                           /* ClusterRevision auto added by LIST_END */
 
 // Contact sensor cluster list

--- a/libraries/Matter/src/MatterDoorLock.cpp
+++ b/libraries/Matter/src/MatterDoorLock.cpp
@@ -43,7 +43,7 @@ constexpr CommandId doorLockIncomingCommands[] = {
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(doorLockAttrs)
 DECLARE_DYNAMIC_ATTRIBUTE(DoorLock::Attributes::LockState::Id, INT8U, 1, ATTRIBUTE_MASK_NULLABLE),  // LockState
 DECLARE_DYNAMIC_ATTRIBUTE(DoorLock::Attributes::LockType::Id, INT8U, 1, 0),                         // LockType
-DECLARE_DYNAMIC_ATTRIBUTE(DoorLock::Attributes::ActuatorEnabled::Id, INT8U, 1, 0),                  // ActuatorEnabled
+DECLARE_DYNAMIC_ATTRIBUTE(DoorLock::Attributes::ActuatorEnabled::Id, BOOLEAN, 1, 0),                // ActuatorEnabled
 DECLARE_DYNAMIC_ATTRIBUTE(DoorLock::Attributes::OperatingMode::Id, INT8U, 1, 0),                    // OperatingMode
 DECLARE_DYNAMIC_ATTRIBUTE(DoorLock::Attributes::SupportedOperatingModes::Id, INT16U, 2, 0),         // SupportedOperatingModes
 DECLARE_DYNAMIC_ATTRIBUTE(DoorLock::Attributes::FeatureMap::Id, BITMAP32, 4, 0),                    // FeatureMap


### PR DESCRIPTION
I've noticed my Home Assistant Matter integration to crash when connecting a device flashed with the MatterContact example. Please see related issue for more details.

I've traced this issue back to MatterContact and MatterDoorLock using incorrect attributes of type INT8U instead of BOOLEAN as specified in the Matter 1.4 Application Cluster Specification. 

Please note that this PR may not be complete. I didn't do an exhaustive scan for further incorrect attribute types.