### PR TITLE
Fix SPI driver reinitialization every time beginTransaction is called

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -62,6 +62,7 @@ void SilabsSPI::beginTransaction(SPISettings settings)
       && this->settings.getDataMode() == settings.getDataMode()) {
     return;
   }
+  this->settings = settings;
   // Deinit the peripheral
   SPIDRV_DeInit(this->sl_spidrv_handle);
   // Apply the new settings


### PR DESCRIPTION
I noticed that calling `SilabsSPI::beginTransaction` was taking too much time every time. For the following interrupt code example:

```cpp
void interruptTest() 
{
   // First toggle
   digitalWrite(CS_PIN, LOW);
   digitalWrite(CS_PIN, HIGH);
   // Empty transaction
   SPI.beginTransaction(SPISettings(4'000'000, MSBFIRST, SPI_MODE1));
   SPI.endTransaction();
   // Second Toggle
   digitalWrite(CS_PIN, LOW);
   digitalWrite(CS_PIN, HIGH);

   // 12 byte transaction
   // Device specific code omitted
}
```

### Before fix:

<img width="1757" height="820" alt="before_fix" src="https://github.com/user-attachments/assets/993fc884-c6e9-45cd-85f2-f094dc84f552" />

### After fix:

Interrupt response time is halved

<img width="1095" height="853" alt="after_fix" src="https://github.com/user-attachments/assets/24a60f9f-2841-4fc8-8e2b-e7275ca027d1" />
