### PR TITLE
Add macro for vsnprintf_P

### DIFF
--- a/cores/gecko/avr/pgmspace.h
+++ b/cores/gecko/avr/pgmspace.h
@@ -97,6 +97,7 @@ typedef const void* uint_farptr_t;
 #define memcmp_PF(s1, s2, n) memcmp((s1), (s2), (n))
 
 #define sprintf_P(s, f, ...) sprintf((s), (f), __VA_ARGS__)
+#define vsnprintf_P(str, size, format, ap) vsnprintf(str, size, format, ap)
 
 #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))


### PR DESCRIPTION
Libraries may depend on this to expand argument lists from flash backed strings.