### PR TITLE
Matter: add UniqueID attribute to BridgedDeviceBasicInformation cluster

### DIFF
--- a/libraries/Matter/src/Matter.cpp
+++ b/libraries/Matter/src/Matter.cpp
@@ -54,6 +54,7 @@ DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::
 DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::VendorName::Id, CHAR_STRING, Device::DeviceDescStrSize, 0),   /* VendorName */
 DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::ProductName::Id, CHAR_STRING, Device::DeviceDescStrSize, 0),  /* ProductName */
 DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::SerialNumber::Id, CHAR_STRING, Device::DeviceDescStrSize, 0), /* SerialNumber */
+DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::UniqueID::Id, CHAR_STRING, Device::DeviceDescStrSize, 0),     /* UniqueID */
 DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::Reachable::Id, BOOLEAN, 1, 0),                                /* Reachable */
 DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::FeatureMap::Id, BITMAP32, 4, 0),                              /* FeatureMap */
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();                                                                                              /* ClusterRevision auto added by LIST_END */

--- a/libraries/Matter/src/Matter.h
+++ b/libraries/Matter/src/Matter.h
@@ -44,7 +44,7 @@
 
 using ::chip::CommandId;
 
-extern EmberAfAttributeMetadata bridgedDeviceBasicAttrs[7];
+extern EmberAfAttributeMetadata bridgedDeviceBasicAttrs[8];
 extern EmberAfAttributeMetadata descriptorAttrs[6];
 extern EmberAfAttributeMetadata identifyAttrs[4];
 extern CommandId identifyIncomingCommands[2];

--- a/libraries/Matter/src/devices/MatterDevice.cpp
+++ b/libraries/Matter/src/devices/MatterDevice.cpp
@@ -22,6 +22,7 @@
 #include "MatterDevice.h"
 
 #include <cstdio>
+#include <silabs_additional.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <app-common/zap-generated/callback.h>
 
@@ -45,6 +46,7 @@ Device::Device(const char* device_name) :
   chip::Platform::CopyString(this->vendor_name, "Silicon Labs");
   chip::Platform::CopyString(this->product_name, "Matter device");
   chip::Platform::CopyString(this->serial_number, "0000000042");
+  snprintf(this->unique_id, sizeof(this->unique_id), "silabs-%s", getDeviceUniqueIdStr().c_str());
 }
 
 bool Device::IsReachable()
@@ -113,6 +115,16 @@ void Device::SetSerialNumber(const char* serialnumber)
     ChipLogProgress(DeviceLayer, "Device[%s]: New SerialNumber=\"%s\"", this->device_name, serialnumber);
     chip::Platform::CopyString(this->serial_number, serialnumber);
     this->HandleDeviceStatusChanged(kChanged_SerialNumber);
+  }
+}
+
+void Device::SetUniqueID(const char* uniqueid)
+{
+  bool changed = (strncmp(this->unique_id, uniqueid, sizeof(this->unique_id)) != 0);
+  if (changed) {
+    ChipLogProgress(DeviceLayer, "Device[%s]: New UniqueID=\"%s\"", this->device_name, uniqueid);
+    chip::Platform::CopyString(this->unique_id, uniqueid);
+    this->HandleDeviceStatusChanged(kChanged_UniqueID);
   }
 }
 
@@ -193,6 +205,9 @@ CHIP_ERROR Device::HandleReadBridgedDeviceBasicAttribute(ClusterId clusterId,
   } else if ((attributeId == SerialNumber::Id) && (maxReadLength == 32)) {
     MutableByteSpan zclNameSpan(buffer, maxReadLength);
     MakeZclCharString(zclNameSpan, this->GetSerialNumber());
+  } else if ((attributeId == UniqueID::Id) && (maxReadLength == 32)) {
+    MutableByteSpan zclNameSpan(buffer, maxReadLength);
+    MakeZclCharString(zclNameSpan, this->GetUniqueID());
   } else if ((attributeId == ClusterRevision::Id) && (maxReadLength == 2)) {
     uint16_t rev = this->GetBridgedDeviceBasicInformationClusterRevision();
     memcpy(buffer, &rev, sizeof(rev));
@@ -224,6 +239,9 @@ void Device::HandleDeviceStatusChanged(Changed_t itemChangedMask)
   }
   if (itemChangedMask & kChanged_SerialNumber) {
     ScheduleMatterReportingCallback(this->endpoint_id, BridgedDeviceBasicInformation::Id, BridgedDeviceBasicInformation::Attributes::SerialNumber::Id);
+  }
+  if (itemChangedMask & kChanged_UniqueID) {
+    ScheduleMatterReportingCallback(this->endpoint_id, BridgedDeviceBasicInformation::Id, BridgedDeviceBasicInformation::Attributes::UniqueID::Id);
   }
 }
 

--- a/libraries/Matter/src/devices/MatterDevice.h
+++ b/libraries/Matter/src/devices/MatterDevice.h
@@ -48,7 +48,8 @@ public:
     kChanged_VendorName   = 1u << 3,
     kChanged_ProductName  = 1u << 4,
     kChanged_SerialNumber = 1u << 5,
-    kChanged_Last         = kChanged_SerialNumber,
+    kChanged_UniqueID     = 1u << 6,
+    kChanged_Last         = kChanged_UniqueID,
   } Changed;
 
   enum device_type_t {
@@ -91,6 +92,7 @@ public:
   void SetVendorName(const char* vendorname);
   void SetProductName(const char* productname);
   void SetSerialNumber(const char* serialnumber);
+  void SetUniqueID(const char* uniqueid);
   void SetLocation(std::string location);
   void SetDeviceChangeCallback(void (*matter_device_change_cb)(void));
   void CallDeviceChangeCallback();
@@ -179,6 +181,11 @@ public:
     return this->serial_number;
   }
 
+  inline char* GetUniqueID()
+  {
+    return this->unique_id;
+  }
+
   inline std::string GetLocation()
   {
     return this->location;
@@ -206,6 +213,7 @@ protected:
   char vendor_name[DeviceDescStrSize];
   char product_name[DeviceDescStrSize];
   char serial_number[DeviceDescStrSize];
+  char unique_id[DeviceDescStrSize];
   std::string location;
   chip::EndpointId endpoint_id;
   chip::EndpointId parent_endpoint_id;


### PR DESCRIPTION
## Problem

`UniqueID` became a mandatory attribute in Matter 1.4 for the `BridgedDeviceBasicInformation` cluster. Its absence causes controllers such as Home Assistant to fail to create entities for bridged endpoints — the controller cannot stably identify a bridged device across re-pairings or bridge restarts, so it refuses to add it.

## Changes

**`MatterDevice.h`**
- Add `kChanged_UniqueID = 1u << 6` to the `Changed_t` enum; update `kChanged_Last` to match
- Add `void SetUniqueID(const char* uniqueid)` declaration
- Add `inline char* GetUniqueID()` getter
- Add `char unique_id[DeviceDescStrSize]` protected member

**`MatterDevice.cpp`**
- Include `em_system.h`
- In the constructor, populate `unique_id` from `SYSTEM_GetUnique()` using the format `"silabs-%016llx"`, giving each bridged endpoint a stable, hardware-derived identity
- Add `Device::SetUniqueID()` implementation (mirrors `SetSerialNumber`)
- Add `UniqueID::Id` read handler in `HandleReadBridgedDeviceBasicAttribute`
- Add `kChanged_UniqueID` block in `HandleDeviceStatusChanged` to schedule reporting callbacks

**`Matter.cpp`**
- Add `DECLARE_DYNAMIC_ATTRIBUTE` for `UniqueID::Id` after `SerialNumber` in `bridgedDeviceBasicAttrs`

**`Matter.h`**
- Bump `bridgedDeviceBasicAttrs` extern array size from `7` to `8`

Note: `bridged_device_basic_information_cluster_revision` is left at `4`, matching the current Matter 1.4 spec revision for this cluster — revision 4 already covers making `UniqueID` mandatory, so no further bump is needed.

## Testing

Cherry-picked from #166 (verified there on an xiao_mg24 running a Matter bridge sketch; Home Assistant successfully discovered and created entities for all bridged endpoints).