### PR TITLE
Document MatterWaterValve in Matter library README

### DIFF
--- a/libraries/Matter/readme.md
+++ b/libraries/Matter/readme.md
@@ -67,6 +67,7 @@ Read more and get the Raspberry Pi OTBR image [here](https://docs.silabs.com/mat
  - Switch
  - Temperature measurement
  - Thermostat
+ - Water valve
  - Window covering
 
 ## Setting up your Arduino device
@@ -583,6 +584,32 @@ Sets a callback invoked when the timezone list is updated by the controller.
 ```float get_measured_value();```
 
 ```void set_measured_value(uint32_t value);```
+
+## class MatterWaterValve
+
+```void open();```
+
+```void open(uint32_t duration_seconds);```
+
+```void close();```
+
+```valve_state_t get_current_state();```
+
+```valve_state_t get_target_state();```
+
+```uint32_t get_open_duration();```
+
+```uint32_t get_default_open_duration();```
+
+```void set_default_open_duration(uint32_t duration_seconds);```
+
+```uint32_t get_remaining_duration();```
+
+```void set_remaining_duration(uint32_t remaining_duration_seconds);```
+
+```uint16_t get_valve_fault();```
+
+```void set_valve_fault(valve_fault_t valve_fault);```
 
 ## class MatterWindowCovering
 


### PR DESCRIPTION
# Document MatterWaterValve in Matter library README

## Summary

- Follow-up to #182 — adds the missing README documentation for the Matter Water Valve appliance, as requested in [review comment](https://github.com/SiliconLabsSoftware/arduino/pull/182#issuecomment-5392993517).
- Adds `Water valve` to the "Supported Matter devices" list.
- Adds a `## class MatterWaterValve` API reference section documenting `open()`/`open(duration)`/`close()`, state getters, and the duration/fault accessors.

## Test plan

- [x] Docs-only change, no code touched.
- [x] Verified the new section's method signatures match `libraries/Matter/src/MatterWaterValve.h` on the `Matter-WaterValve` branch (#182).
- [x] Checked markdown renders correctly (heading level, list placement, code fences).